### PR TITLE
Xml type has to precede comments.

### DIFF
--- a/JavaTraits/pom.xml
+++ b/JavaTraits/pom.xml
@@ -1,6 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Sam Bosley 
  See the file "LICENSE" for the full license governing this code.-->
-<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/JavaTraitsTest/pom.xml
+++ b/JavaTraitsTest/pom.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Sam Bosley 
- See the file "LICENSE" for the full license governing this code.--><?xml version="1.0" encoding="UTF-8"?>
+ See the file "LICENSE" for the full license governing this code.-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
Found the problem. Comments can't come before the version tag.

Also, I was wrong about needing to `cd JavaTraits`. You should be able to run `mvn clean install` from the top directory.
