### PR TITLE
Several modifications that we use in our local fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 */bin
 */.gradle
 */build
+target
+*.iml

--- a/apt-utils/src/com/yahoo/aptutils/model/DeclaredTypeName.java
+++ b/apt-utils/src/com/yahoo/aptutils/model/DeclaredTypeName.java
@@ -40,8 +40,8 @@ public class DeclaredTypeName extends TypeName {
     }
 
     public DeclaredTypeName(String fullyQualifiedName) {
-        this.packageName = AptUtils.getPackageFromFullyQualifiedName(fullyQualifiedName);
-        this.simpleName = AptUtils.getSimpleNameFromFullyQualifiedName(fullyQualifiedName);
+        this(AptUtils.getPackageFromFullyQualifiedName(fullyQualifiedName),
+                AptUtils.getSimpleNameFromFullyQualifiedName(fullyQualifiedName));
     }
 
     @Override

--- a/apt-utils/src/com/yahoo/aptutils/utils/AptUtils.java
+++ b/apt-utils/src/com/yahoo/aptutils/utils/AptUtils.java
@@ -408,7 +408,8 @@ public class AptUtils {
             .setMethodGenerics(methodGenerics)
             .setArgumentTypes(arguments.getLeft())
             .setArgumentNames(arguments.getRight())
-            .setThrowsTypes(getThrownTypes(exec, genericQualifier, methodGenerics));
+            .setThrowsTypes(getThrownTypes(exec, genericQualifier, methodGenerics))
+            .setAnnotations(exec.getAnnotationMirrors());
     }
 
     private TypeName getReturnTypeName(ExecutableElement exec, String genericQualifier, List<TypeName> methodGenerics) {

--- a/apt-utils/src/com/yahoo/aptutils/writer/JavaFileWriter.java
+++ b/apt-utils/src/com/yahoo/aptutils/writer/JavaFileWriter.java
@@ -25,6 +25,7 @@ import com.yahoo.aptutils.writer.expressions.Expression;
 import com.yahoo.aptutils.writer.parameters.MethodDeclarationParameters;
 import com.yahoo.aptutils.writer.parameters.TypeDeclarationParameters;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
@@ -308,6 +309,13 @@ public class JavaFileWriter {
         validateMethodDefinitionParams(methodDeclaration);
         checkScope(Scope.TYPE_DEFINITION);
         indent();
+        if(!AptUtils.isEmpty(methodDeclaration.getAnnotations())){
+            for(AnnotationMirror annotationMirror:methodDeclaration.getAnnotations()) {
+                out.write(annotationMirror.toString());
+                out.append("\n");
+                indent();
+            }
+        }
         boolean isAbstract = kind.equals(Type.INTERFACE) ||
                 (!AptUtils.isEmpty(methodDeclaration.getModifiers())
                         && methodDeclaration.getModifiers().contains(Modifier.ABSTRACT));

--- a/apt-utils/src/com/yahoo/aptutils/writer/JavaFileWriter.java
+++ b/apt-utils/src/com/yahoo/aptutils/writer/JavaFileWriter.java
@@ -140,7 +140,7 @@ public class JavaFileWriter {
         if (!AptUtils.isEmpty(imports)) {
             for (DeclaredTypeName item : imports) {
                 DeclaredTypeName toImport = addToKnownNames(item, item.isJavaLangPackage() || item.getPackageName().equals(packageName));
-                if (toImport != null) {
+                if (toImport != null && toImport.getPackageName() != null && !toImport.getPackageName().isEmpty()) {
                     sortedImports.add(toImport.toString());
                 }
             }

--- a/apt-utils/src/com/yahoo/aptutils/writer/parameters/MethodDeclarationParameters.java
+++ b/apt-utils/src/com/yahoo/aptutils/writer/parameters/MethodDeclarationParameters.java
@@ -19,6 +19,7 @@ import com.yahoo.aptutils.model.DeclaredTypeName;
 import com.yahoo.aptutils.model.TypeName;
 import com.yahoo.aptutils.utils.AptUtils;
 
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Modifier;
 import java.util.List;
 
@@ -40,6 +41,7 @@ public class MethodDeclarationParameters {
     private List<? extends TypeName> argumentTypes;
     private List<String> argumentNames;
     private List<? extends TypeName> throwsTypes;
+    private List<? extends AnnotationMirror> annotations;
     
     public boolean isConstructor() {
         return getConstructorName() != null;
@@ -131,5 +133,13 @@ public class MethodDeclarationParameters {
         this.throwsTypes = throwsTypes;
         return this;
     }
-    
+
+    public List<? extends AnnotationMirror> getAnnotations() {
+        return annotations;
+    }
+
+    public MethodDeclarationParameters setAnnotations(List<? extends AnnotationMirror> annotations) {
+        this.annotations = annotations;
+        return this;
+    }
 }

--- a/java-traits-test/pom.xml
+++ b/java-traits-test/pom.xml
@@ -13,6 +13,7 @@
         <groupId>com.yahoo.javatraits</groupId>
         <artifactId>pom</artifactId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <build>
@@ -34,7 +35,16 @@
                     <outputDirectory>target/generated-sources</outputDirectory>
                     <processors>
                         <processor>com.yahoo.javatraits.processor.TraitProcessor</processor>
+                        <processor>com.yahoo.javatraits.processor.HasTraitsProcessor</processor>
                     </processors>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <testSourceDirectory>${basedir}/src/</testSourceDirectory>
+                    <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
                 </configuration>
             </plugin>
         </plugins>
@@ -46,6 +56,11 @@
             <artifactId>JavaTraits</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
@@ -18,10 +18,12 @@ package com.yahoo.javatraits.test;
 import com.yahoo.javatraits.test.traits.*;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class BasicTraitsTest {
@@ -90,6 +92,12 @@ public class BasicTraitsTest {
     public void testTraitVariables() {
        instance.setTestVariable(5);
         assertEquals(5, instance.getTestVariable());
+    }
+
+    @Test
+    public void testCopyAnnotations() throws NoSuchMethodException {
+        Method method=SomeClass.class.getMethod("intToStringV2", int.class);
+        assertNotNull(method.getAnnotation(Deprecated.class));
     }
 
 }

--- a/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
@@ -83,7 +83,7 @@ public class BasicTraitsTest {
 
     @Test
     public void testTraitExtendingInterface() {
-        IBetterList<String> list = new BetterArrayList<String>();
+        IBetterList<String, IRectangular> list = new BetterArrayList<>();
         assertTrue(list instanceof List);
         assertTrue(list instanceof IBetterList);
     }

--- a/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
@@ -15,6 +15,10 @@
  */
 package com.yahoo.javatraits.test;
 
+import com.yahoo.javatraits.test.classes.BetterArrayList;
+import com.yahoo.javatraits.test.classes.FootballField;
+import com.yahoo.javatraits.test.classes.LyingRectangle;
+import com.yahoo.javatraits.test.classes.SomeClass;
 import com.yahoo.javatraits.test.traits.*;
 import org.junit.Test;
 

--- a/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/BasicTraitsTest.java
@@ -86,4 +86,10 @@ public class BasicTraitsTest {
         assertTrue(list instanceof IBetterList);
     }
 
+    @Test
+    public void testTraitVariables() {
+       instance.setTestVariable(5);
+        assertEquals(5, instance.getTestVariable());
+    }
+
 }

--- a/java-traits-test/src/com/yahoo/javatraits/test/traits/AnotherTrait.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/traits/AnotherTrait.java
@@ -53,7 +53,8 @@ public abstract class AnotherTrait<A, B> {
     public String intToStringV1(int someArg) {
         return Integer.toBinaryString(someArg);
     }
-    
+
+    @Deprecated
     public String intToStringV2(int someArg) {
         return Integer.toBinaryString(someArg);
     }

--- a/java-traits-test/src/com/yahoo/javatraits/test/traits/AnotherTrait.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/traits/AnotherTrait.java
@@ -19,7 +19,17 @@ import com.yahoo.javatraits.annotations.Trait;
 
 @Trait
 public abstract class AnotherTrait<A, B> {
-    
+
+    private int testVariable;
+
+    public int getTestVariable() {
+        return testVariable;
+    }
+
+    public void setTestVariable(int testVariable) {
+        this.testVariable = testVariable;
+    }
+
     public abstract A[] copyANTimes(A a, int n);
     
     public abstract B[] copyBNTimes(B b, int n);

--- a/java-traits-test/src/com/yahoo/javatraits/test/traits/BetterArrayList.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/traits/BetterArrayList.java
@@ -22,5 +22,5 @@ import java.util.ArrayList;
 
 @HasTraits(traits=BetterList.class,
         desiredSuperclass=@DesiredSuperclass(superclass=ArrayList.class, typeArgNames = "BetterList_T"))
-public class BetterArrayList<T extends CharSequence> extends BetterArrayListWithTraits<T> {
+public class BetterArrayList<T extends CharSequence> extends BetterArrayListWithTraits<T, IRectangular> {
 }

--- a/java-traits-test/src/com/yahoo/javatraits/test/traits/BetterList.java
+++ b/java-traits-test/src/com/yahoo/javatraits/test/traits/BetterList.java
@@ -20,7 +20,7 @@ import com.yahoo.javatraits.annotations.Trait;
 import java.util.List;
 
 @Trait
-public abstract class BetterList<T extends CharSequence> implements List<T> {
+public abstract class BetterList<T extends CharSequence, S extends IRectangular> implements List<T> {
 
     public void printAll() {
         for (int i = 0; i < size(); i++) {

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/BetterArrayList.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/BetterArrayList.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Yahoo Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.javatraits.test.classes;
+
+import com.yahoo.javatraits.annotations.DesiredSuperclass;
+import com.yahoo.javatraits.annotations.HasTraits;
+import com.yahoo.javatraits.test.traits.BetterList;
+import com.yahoo.javatraits.test.traits.IRectangular;
+
+import java.util.ArrayList;
+
+@HasTraits(traits=BetterList.class,
+        desiredSuperclass=@DesiredSuperclass(superclass=ArrayList.class, typeArgNames = "BetterList_T"))
+public class BetterArrayList<T extends CharSequence> extends BetterArrayListWithTraits<T, IRectangular> {
+}

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/FootballField.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/FootballField.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 Yahoo Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.javatraits.test.classes;
+
+import com.yahoo.javatraits.annotations.HasTraits;
+import com.yahoo.javatraits.test.traits.Rectangular;
+
+@HasTraits(traits=Rectangular.class)
+public class FootballField extends FootballFieldWithTraits {
+
+    public static final int WIDTH = 160;
+    public static final int HEIGHT = 320;
+    
+    @Override
+    public int getWidth() {
+        return WIDTH;
+    }
+
+    @Override
+    public int getHeight() {
+        return HEIGHT;
+    }
+
+}

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
@@ -37,7 +37,7 @@ public class LyingRectangle extends LyingRectangleWithTraits {
     }
 
     @HasTraits(traits=Rectangular.class)
-    public class InnerRectangle extends InnerRectangleWithTraits{
+    public class InnerRectangle extends LyingRectangle_InnerRectangleWithTraits{
 
         @Override
         public int getWidth() {

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
@@ -35,5 +35,18 @@ public class LyingRectangle extends LyingRectangleWithTraits {
     public int getArea() {
         return 0;
     }
-    
+
+    @HasTraits(traits=Rectangular.class)
+    public class InnerRectangle extends InnerRectangleWithTraits{
+
+        @Override
+        public int getWidth() {
+            return LyingRectangle.this.getWidth()/2;
+        }
+
+        @Override
+        public int getHeight() {
+            return LyingRectangle.this.getHeight()/2;
+        }
+    }
 }

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/LyingRectangle.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Yahoo Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.javatraits.test.classes;
+
+import com.yahoo.javatraits.annotations.HasTraits;
+import com.yahoo.javatraits.test.traits.Rectangular;
+
+@HasTraits(traits=Rectangular.class)
+public class LyingRectangle extends LyingRectangleWithTraits {
+
+    @Override
+    public int getWidth() {
+        return 1;
+    }
+
+    @Override
+    public int getHeight() {
+        return 1;
+    }
+    
+    @Override
+    public int getArea() {
+        return 0;
+    }
+    
+}

--- a/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/SomeClass.java
+++ b/java-traits-test/src/test/java/com/yahoo/javatraits/test/classes/SomeClass.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 Yahoo Inc.
+
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.javatraits.test.classes;
+
+import com.yahoo.javatraits.annotations.DesiredSuperclass;
+import com.yahoo.javatraits.annotations.HasTraits;
+import com.yahoo.javatraits.annotations.Prefer;
+import com.yahoo.javatraits.test.traits.AnotherTrait;
+import com.yahoo.javatraits.test.traits.MathTrait;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+@HasTraits(traits={MathTrait.class, AnotherTrait.class},
+           desiredSuperclass=@DesiredSuperclass(superclass=HashMap.class, typeArgClasses={String.class, Long.class}),
+           prefer=@Prefer(target=AnotherTrait.class, method="intToStringV2"))
+public class SomeClass<A extends Number, B extends A, C, D> extends SomeClassWithTraits<A, B, C, D> {
+
+    @Override
+    public int someWeirdOp(int arg1, int arg2) {
+        return 0;
+    }
+
+    @Override
+    public B transform(A a) {
+        return null;
+    }
+
+    @Override
+    public C[] copyANTimes(C a, int n) {
+        return null;
+    }
+
+    @Override
+    public D[] copyBNTimes(D a, int n) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ArrayList<B[]>>[][] getParametrizedArg() {
+        return null;
+    }
+
+    @Override
+    public <T extends Number & Runnable> void testIntersectionType(T arg) {
+        arg.run();
+    }
+
+}

--- a/java-traits/pom.xml
+++ b/java-traits/pom.xml
@@ -14,11 +14,20 @@
         <groupId>com.yahoo.javatraits</groupId>
         <artifactId>pom</artifactId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.javatraits</groupId>
+            <artifactId>apt-utils</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -28,8 +37,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
             </plugins>

--- a/java-traits/src/com/yahoo/javatraits/processor/JavaTraitsProcessor.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/JavaTraitsProcessor.java
@@ -54,7 +54,7 @@ public abstract class JavaTraitsProcessor<T extends TypeElementWrapper> extends 
 
         this.messager = env.getMessager();
         this.filer = env.getFiler();
-        this.utils = new TraitProcessorAptUtils(messager, env.getTypeUtils(), env.getElementUtils());
+        this.utils = new TraitProcessorAptUtils(env);
     }
     
     @Override

--- a/java-traits/src/com/yahoo/javatraits/processor/data/TraitElement.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/data/TraitElement.java
@@ -69,8 +69,10 @@ public class TraitElement extends TypeElementWrapper {
                     }
                 } else if (elementIsConstant(e)) {
                     constants.add((VariableElement) e);
+                } else if (e.getModifiers().contains(Modifier.PRIVATE)) {
+                    //do nothing
                 } else {
-                    aptUtils.getMessager().printMessage(Kind.ERROR, "Trait elements may only declare methods, abstract methods, or public static final variables", e);
+                    aptUtils.getMessager().printMessage(Kind.ERROR, "Trait elements may only declare methods, abstract methods, private fields or public static final variables", e);
                 }
             } else {
                 methods.add((ExecutableElement) e);

--- a/java-traits/src/com/yahoo/javatraits/processor/data/TypeElementWrapper.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/data/TypeElementWrapper.java
@@ -19,6 +19,8 @@ import com.yahoo.aptutils.model.DeclaredTypeName;
 import com.yahoo.aptutils.model.TypeName;
 import com.yahoo.aptutils.utils.AptUtils;
 
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import java.util.List;
 
@@ -32,7 +34,11 @@ public abstract class TypeElementWrapper {
     public TypeElementWrapper(TypeElement elem, AptUtils aptUtils) {
         this.elem = elem;
         this.aptUtils = aptUtils;
-        this.elementName = new DeclaredTypeName(elem.getQualifiedName().toString());
+        Element pack=elem.getEnclosingElement();
+        while(pack.getKind()!=ElementKind.PACKAGE){
+            pack=pack.getEnclosingElement();
+        }
+        this.elementName = new DeclaredTypeName(pack.toString(),elem.getSimpleName().toString());
         this.typeParameters = aptUtils.typeParameterElementsToTypeNames(elem.getTypeParameters(), getSimpleName());
     }
 

--- a/java-traits/src/com/yahoo/javatraits/processor/data/TypeElementWrapper.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/data/TypeElementWrapper.java
@@ -35,10 +35,12 @@ public abstract class TypeElementWrapper {
         this.elem = elem;
         this.aptUtils = aptUtils;
         Element pack=elem.getEnclosingElement();
+        String prefix="";
         while(pack.getKind()!=ElementKind.PACKAGE){
+            prefix+=pack.getSimpleName().toString()+"_";
             pack=pack.getEnclosingElement();
         }
-        this.elementName = new DeclaredTypeName(pack.toString(),elem.getSimpleName().toString());
+        this.elementName = new DeclaredTypeName(pack.toString(),prefix+elem.getSimpleName().toString());
         this.typeParameters = aptUtils.typeParameterElementsToTypeNames(elem.getTypeParameters(), getSimpleName());
     }
 

--- a/java-traits/src/com/yahoo/javatraits/processor/utils/TraitProcessorAptUtils.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/utils/TraitProcessorAptUtils.java
@@ -18,18 +18,16 @@ package com.yahoo.javatraits.processor.utils;
 import com.yahoo.aptutils.utils.AptUtils;
 import com.yahoo.javatraits.processor.data.TraitElement;
 
-import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.ErrorType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
-import javax.lang.model.util.Types;
 
 public class TraitProcessorAptUtils extends AptUtils {
 
-    public TraitProcessorAptUtils(Messager messager, Types types, Elements elements) {
-        super(messager, types, elements);
+    public TraitProcessorAptUtils(ProcessingEnvironment processingEnvironment) {
+        super(processingEnvironment);
     }
 
     public static final String GET_THIS = "getThis";

--- a/java-traits/src/com/yahoo/javatraits/processor/writers/ClassWithTraitsSuperclassWriter.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/writers/ClassWithTraitsSuperclassWriter.java
@@ -54,6 +54,13 @@ public class ClassWithTraitsSuperclassWriter extends JavaTraitsWriter<ClassWithT
     @Override
     protected void gatherImports(Set<DeclaredTypeName> imports) {
         for (TraitElement elem : allTraits) {
+            utils.accumulateImportsFromTypeNames(imports, elem.getTypeParameters());
+            new HashSet<>(imports).stream().filter(n -> n.getPackageName().isEmpty()).forEach(n -> {
+                DeclaredTypeName n2 = new DeclaredTypeName(elem.getPackageName(), n.getSimpleName());
+                n2.setTypeArgs(n.getTypeArgs());
+                imports.remove(n);
+                imports.add(n2);
+            });
             utils.accumulateImportsFromElements(imports, elem.getDeclaredMethods());
             imports.add(elem.getDelegateName());
             imports.add(elem.getGeneratedInterfaceName());

--- a/java-traits/src/com/yahoo/javatraits/processor/writers/TraitInterfaceWriter.java
+++ b/java-traits/src/com/yahoo/javatraits/processor/writers/TraitInterfaceWriter.java
@@ -40,6 +40,7 @@ public class TraitInterfaceWriter extends JavaTraitsWriter<TraitElement> {
 
     @Override
     protected void gatherImports(Set<DeclaredTypeName> imports) {
+        utils.accumulateImportsFromTypeNames(imports, element.getTypeParameters());
         utils.accumulateImportsFromTypeNames(imports, element.getInterfaceNames());
         utils.accumulateImportsFromElements(imports, element.getDeclaredMethods());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>JavaTraits</module>
-        <module>JavaTraitsTest</module>
+        <module>java-traits</module>
+        <module>java-traits-test</module>
     </modules>
 
     <properties>
@@ -27,8 +27,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <compilerArgument>-proc:none</compilerArgument>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
We use java traits to generate DTO classes from traits. To do that we have added some custom modifications:

- allow Trait classes to have private fields
- copy over annotations from trait classes to the wrapper class
- allow the HasTrait annotation on inner classes
- generic type parameters were not imported
- allow the generated interfaces to be used inside type parameters of Traits

also I fixed the pom files, so that we could build the project

Maybe something from this is useful for you, too. :)